### PR TITLE
Align generator output with our edited generated code

### DIFF
--- a/n2k-codegen/bin/cli.rs
+++ b/n2k-codegen/bin/cli.rs
@@ -1,5 +1,5 @@
 use n2k_codegen::N2kCodeGenOpts;
-use std::{collections::HashSet, path::PathBuf};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]

--- a/n2k-codegen/pgns.xml
+++ b/n2k-codegen/pgns.xml
@@ -2731,7 +2731,7 @@ limitations under the License.
             <EnumPair Value='4' Name='Main Cabin Temperature' />
             <EnumPair Value='5' Name='Live Well Temperature' />
             <EnumPair Value='6' Name='Bait Well Temperature' />
-            <EnumPair Value='7' Name='Refridgeration Temperature' />
+            <EnumPair Value='7' Name='Refrigeration Temperature' />
             <EnumPair Value='8' Name='Heating System Temperature' />
             <EnumPair Value='9' Name='Dew Point Temperature' />
             <EnumPair Value='10' Name='Apparent Wind Chill Temperature' />
@@ -7060,8 +7060,8 @@ limitations under the License.
         </Field>
         <Field>
           <Order>5</Order>
-          <Id>cogSubstitionForHdg</Id>
-          <Name>COG substition for HDG</Name>
+          <Id>cogSubstitutionForHdg</Id>
+          <Name>COG substitution for HDG</Name>
           <Description>Allow use of COG when HDG not available?</Description>
           <BitLength>2</BitLength>
           <BitOffset>24</BitOffset>
@@ -8675,7 +8675,7 @@ limitations under the License.
             <EnumPair Value='16' Name='Portuguese' />
             <EnumPair Value='17' Name='Russian' />
             <EnumPair Value='18' Name='Spanish' />
-            <EnumPair Value='19' Name='Sweedish' />
+            <EnumPair Value='19' Name='Swedish' />
           </EnumValues>
         </Field>
         <Field>
@@ -8834,7 +8834,7 @@ limitations under the License.
           <BitOffset>0</BitOffset>
           <BitStart>0</BitStart>
           <Units>s</Units>
-          <Resolution>0.01</Resolution>
+          <Resolution>0.001</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
@@ -8850,12 +8850,60 @@ limitations under the License.
         </Field>
         <Field>
           <Order>3</Order>
+          <Id>controller1State</Id>
+          <Name>Controller 1 State</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>24</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Error Active' />
+            <EnumPair Value='1' Name='Error Passive' />
+            <EnumPair Value='2' Name='Bus Off' />
+            <EnumPair Value='3' Name='Not Available' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>4</Order>
+          <Id>controller2State</Id>
+          <Name>Controller 2 State</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>26</BitOffset>
+          <BitStart>2</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Error Active' />
+            <EnumPair Value='1' Name='Error Passive' />
+            <EnumPair Value='2' Name='Bus Off' />
+            <EnumPair Value='3' Name='Not Available' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>5</Order>
+          <Id>equipmentStatus</Id>
+          <Name>Equipment Status</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>28</BitOffset>
+          <BitStart>4</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Operational' />
+            <EnumPair Value='1' Name='Fault' />
+            <EnumPair Value='2' Name='Reserved' />
+            <EnumPair Value='3' Name='Not Available' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>6</Order>
           <Id>reserved</Id>
           <Name>Reserved</Name>
           <Description>Reserved</Description>
-          <BitLength>24</BitLength>
-          <BitOffset>24</BitOffset>
-          <BitStart>0</BitStart>
+          <BitLength>34</BitLength>
+          <BitOffset>30</BitOffset>
+          <BitStart>6</BitStart>
                  <Type>Binary data</Type>
           <Signed>false</Signed>
         </Field>
@@ -9237,8 +9285,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -9253,8 +9299,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -9269,8 +9313,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -9285,8 +9327,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -9360,7 +9400,7 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No Order' />
             <EnumPair Value='1' Name='Move to starboard' />
-            <EnumPair Value='10' Name='Move to port' />
+            <EnumPair Value='2' Name='Move to port' />
           </EnumValues>
         </Field>
         <Field>
@@ -9485,19 +9525,25 @@ limitations under the License.
           <Order>2</Order>
           <Id>directionOrder</Id>
           <Name>Direction Order</Name>
-          <BitLength>2</BitLength>
+          <BitLength>3</BitLength>
           <BitOffset>8</BitOffset>
           <BitStart>0</BitStart>
+                 <Type>Lookup table</Type>
           <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='No Order' />
+            <EnumPair Value='1' Name='Move to starboard' />
+            <EnumPair Value='2' Name='Move to port' />
+          </EnumValues>
         </Field>
         <Field>
           <Order>3</Order>
           <Id>reserved</Id>
           <Name>Reserved</Name>
           <Description>Reserved</Description>
-          <BitLength>6</BitLength>
-          <BitOffset>10</BitOffset>
-          <BitStart>2</BitStart>
+          <BitLength>5</BitLength>
+          <BitOffset>11</BitOffset>
+          <BitStart>3</BitStart>
                  <Type>Binary data</Type>
           <Signed>false</Signed>
         </Field>
@@ -9522,6 +9568,17 @@ limitations under the License.
           <Units>rad</Units>
           <Resolution>0.0001</Resolution>
           <Signed>true</Signed>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>reserved</Id>
+          <Name>Reserved</Name>
+          <Description>Reserved</Description>
+          <BitLength>16</BitLength>
+          <BitOffset>48</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Binary data</Type>
+          <Signed>false</Signed>
         </Field>
       </Fields>
     </PGNInfo>
@@ -10173,7 +10230,7 @@ limitations under the License.
       <Description>Trip Parameters, Vessel</Description>
       <Type>Fast</Type>
       <Complete>true</Complete>
-      <Length>10</Length>
+      <Length>14</Length>
       <RepeatingFields>0</RepeatingFields>
       <Fields>
         <Field>
@@ -10474,7 +10531,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10489,7 +10545,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10504,7 +10559,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10519,7 +10573,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10534,7 +10587,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10549,7 +10601,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10564,7 +10615,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10579,7 +10629,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10594,7 +10643,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10609,7 +10657,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10624,7 +10671,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10639,7 +10685,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10654,7 +10699,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10669,7 +10713,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10684,7 +10727,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10699,7 +10741,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10714,7 +10755,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10729,7 +10769,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10744,7 +10783,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10759,7 +10797,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10774,7 +10811,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10789,7 +10825,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10804,7 +10839,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10819,7 +10853,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10834,7 +10867,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10849,7 +10881,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10864,7 +10895,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -10879,7 +10909,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
       </Fields>
@@ -10895,8 +10924,8 @@ limitations under the License.
       <Fields>
         <Field>
           <Order>1</Order>
-          <Id>switchBankInstance</Id>
-          <Name>Switch Bank Instance</Name>
+          <Id>instance</Id>
+          <Name>Instance</Name>
           <BitLength>8</BitLength>
           <BitOffset>0</BitOffset>
           <BitStart>0</BitStart>
@@ -11668,9 +11697,9 @@ limitations under the License.
       <PGN>127506</PGN>
       <Id>dcDetailedStatus</Id>
       <Description>DC Detailed Status</Description>
-      <Type>Single</Type>
+      <Type>Fast</Type>
       <Complete>true</Complete>
-      <Length>9</Length>
+      <Length>11</Length>
       <RepeatingFields>0</RepeatingFields>
       <Fields>
         <Field>
@@ -11746,15 +11775,26 @@ limitations under the License.
           <Resolution>0.01</Resolution>
           <Signed>false</Signed>
         </Field>
+        <Field>
+          <Order>8</Order>
+          <Id>ampHours</Id>
+          <Name>Amp Hours</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>72</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>C</Units>
+          <Resolution>3600</Resolution>
+          <Signed>false</Signed>
+        </Field>
       </Fields>
     </PGNInfo>
     <PGNInfo>
       <PGN>127507</PGN>
       <Id>chargerStatus</Id>
       <Description>Charger Status</Description>
-      <Type>Single</Type>
+      <Type>Fast</Type>
       <Complete>true</Complete>
-      <Length>8</Length>
+      <Length>6</Length>
       <RepeatingFields>0</RepeatingFields>
       <Fields>
         <Field>
@@ -11807,16 +11847,16 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='Standalone mode' />
-            <EnumPair Value='1' Name='Primary mode' />
-            <EnumPair Value='2' Name='Secondary mode' />
-            <EnumPair Value='3' Name='Echo mode' />
+            <EnumPair Value='0' Name='Standalone' />
+            <EnumPair Value='1' Name='Primary' />
+            <EnumPair Value='2' Name='Secondary' />
+            <EnumPair Value='3' Name='Echo' />
           </EnumValues>
         </Field>
         <Field>
           <Order>5</Order>
-          <Id>operatingState</Id>
-          <Name>Operating State</Name>
+          <Id>enabled</Id>
+          <Name>Enabled</Name>
           <BitLength>2</BitLength>
           <BitOffset>24</BitOffset>
           <BitStart>0</BitStart>
@@ -11971,23 +12011,36 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='Standby' />
-            <EnumPair Value='1' Name='On' />
+            <EnumPair Value='0' Name='Invert' />
+            <EnumPair Value='1' Name='AC Passthru' />
+            <EnumPair Value='2' Name='Load Sense' />
+            <EnumPair Value='3' Name='Fault' />
+            <EnumPair Value='4' Name='Disabled' />
+            <EnumPair Value='14' Name='Error' />
+            <EnumPair Value='15' Name='Data Not Available' />
           </EnumValues>
         </Field>
         <Field>
           <Order>5</Order>
-          <Id>inverter</Id>
-          <Name>Inverter</Name>
+          <Id>inverterEnableDisable</Id>
+          <Name>Inverter Enable/Disable</Name>
           <BitLength>2</BitLength>
           <BitOffset>28</BitOffset>
           <BitStart>4</BitStart>
+          <Units>0=Disabled,1=Enabled,2=Error,3=Unknown</Units>
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
-          <EnumValues>
-            <EnumPair Value='0' Name='Standby' />
-            <EnumPair Value='1' Name='On' />
-          </EnumValues>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>reserved</Id>
+          <Name>Reserved</Name>
+          <Description>Reserved</Description>
+          <BitLength>2</BitLength>
+          <BitOffset>30</BitOffset>
+          <BitStart>6</BitStart>
+                 <Type>Binary data</Type>
+          <Signed>false</Signed>
         </Field>
       </Fields>
     </PGNInfo>
@@ -12822,7 +12875,7 @@ limitations under the License.
           <BitStart>0</BitStart>
           <Units>rad</Units>
           <Resolution>0.0001</Resolution>
-          <Signed>false</Signed>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>3</Order>
@@ -12832,6 +12885,286 @@ limitations under the License.
           <BitOffset>24</BitOffset>
           <BitStart>0</BitStart>
                  <Type>Binary data</Type>
+          <Signed>false</Signed>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
+      <PGN>128006</PGN>
+      <Id>thrusterControlStatus</Id>
+      <Description>Thruster Control Status</Description>
+      <Type>Single</Type>
+      <Complete>true</Complete>
+      <Length>8</Length>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>sid</Id>
+          <Name>SID</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>2</Order>
+          <Id>identifier</Id>
+          <Name>Identifier</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>8</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>3</Order>
+          <Id>directionControl</Id>
+          <Name>Direction Control</Name>
+          <BitLength>4</BitLength>
+          <BitOffset>16</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='Ready' />
+            <EnumPair Value='2' Name='To Port' />
+            <EnumPair Value='3' Name='To Starboard' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>4</Order>
+          <Id>powerEnabled</Id>
+          <Name>Power Enabled</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>20</BitOffset>
+          <BitStart>4</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>5</Order>
+          <Id>retractControl</Id>
+          <Name>Retract Control</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>22</BitOffset>
+          <BitStart>6</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='Extend' />
+            <EnumPair Value='2' Name='Retract' />
+            <EnumPair Value='3' Name='Reserved' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>speedControl</Id>
+          <Name>Speed Control</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>24</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>%</Units>
+          <Resolution>0.004</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>7</Order>
+          <Id>controlEvents</Id>
+          <Name>Control Events</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>32</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Bitfield</Type>
+          <Signed>false</Signed>
+          <EnumBitValues>
+            <EnumPair Bit='0' Name='Another device controlling thruster' />
+            <EnumPair Bit='1' Name='Boat speed too fast to safely use thruster' />
+          </EnumBitValues>
+        </Field>
+        <Field>
+          <Order>8</Order>
+          <Id>commandTimeout</Id>
+          <Name>Command Timeout</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>40</BitOffset>
+          <BitStart>0</BitStart>
+          <Resolution>0.001</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>9</Order>
+          <Id>azimuthControl</Id>
+          <Name>Azimuth Control</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>48</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>rad</Units>
+          <Resolution>0.0001</Resolution>
+          <Signed>false</Signed>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
+      <PGN>128007</PGN>
+      <Id>thrusterInformation</Id>
+      <Description>Thruster Information</Description>
+      <Type>Single</Type>
+      <Complete>true</Complete>
+      <Length>8</Length>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>identifier</Id>
+          <Name>Identifier</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>2</Order>
+          <Id>motorType</Id>
+          <Name>Motor Type</Name>
+          <BitLength>4</BitLength>
+          <BitOffset>8</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='12VDC' />
+            <EnumPair Value='1' Name='24VDC' />
+            <EnumPair Value='2' Name='48VDC' />
+            <EnumPair Value='3' Name='24VAC' />
+            <EnumPair Value='4' Name='Hydraulic' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>3</Order>
+          <Id>reserved</Id>
+          <Name>Reserved</Name>
+          <BitLength>4</BitLength>
+          <BitOffset>12</BitOffset>
+          <BitStart>4</BitStart>
+                 <Type>Binary data</Type>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>4</Order>
+          <Id>powerRating</Id>
+          <Name>Power Rating</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>16</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>W</Units>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>5</Order>
+          <Id>maximumTemperatureRating</Id>
+          <Name>Maximum Temperature Rating</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>32</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>K</Units>
+                 <Type>Temperature</Type>
+                 <Resolution>0.01</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>maximumRotationalSpeed</Id>
+          <Name>Maximum Rotational Speed</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>48</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>rpm</Units>
+          <Resolution>0.25</Resolution>
+          <Signed>false</Signed>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
+      <PGN>128008</PGN>
+      <Id>thrusterMotorStatus</Id>
+      <Description>Thruster Motor Status</Description>
+      <Type>Single</Type>
+      <Complete>true</Complete>
+      <Length>8</Length>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>sid</Id>
+          <Name>SID</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>2</Order>
+          <Id>identifier</Id>
+          <Name>Identifier</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>8</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>3</Order>
+          <Id>motorEvents</Id>
+          <Name>Motor Events</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>16</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Bitfield</Type>
+          <Signed>false</Signed>
+          <EnumBitValues>
+            <EnumPair Bit='0' Name='Motor over temperature cutout' />
+            <EnumPair Bit='1' Name='Motor over current cutout' />
+            <EnumPair Bit='2' Name='Low oil level warning' />
+            <EnumPair Bit='3' Name='Oil over temperature warning' />
+            <EnumPair Bit='4' Name='Controller under voltage cutout' />
+            <EnumPair Bit='5' Name='Manufacturer defined' />
+          </EnumBitValues>
+        </Field>
+        <Field>
+          <Order>4</Order>
+          <Id>current</Id>
+          <Name>Current</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>24</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>A</Units>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>5</Order>
+          <Id>temperature</Id>
+          <Name>Temperature</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>32</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>K</Units>
+                 <Type>Temperature</Type>
+                 <Resolution>0.01</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>operatingTime</Id>
+          <Name>Operating Time</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>48</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>minutes</Units>
           <Signed>false</Signed>
         </Field>
       </Fields>
@@ -13088,8 +13421,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -13276,10 +13607,8 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='No' />
-            <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
           </EnumValues>
         </Field>
         <Field>
@@ -13329,10 +13658,8 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='No' />
-            <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
           </EnumValues>
         </Field>
         <Field>
@@ -13345,10 +13672,8 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='No' />
-            <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
           </EnumValues>
         </Field>
         <Field>
@@ -13361,10 +13686,8 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='No' />
-            <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
           </EnumValues>
         </Field>
         <Field>
@@ -13377,10 +13700,8 @@ limitations under the License.
                  <Type>Lookup table</Type>
           <Signed>false</Signed>
           <EnumValues>
-            <EnumPair Value='0' Name='No' />
-            <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
+            <EnumPair Value='0' Name='Off' />
+            <EnumPair Value='1' Name='On' />
           </EnumValues>
         </Field>
         <Field>
@@ -13402,9 +13723,11 @@ limitations under the License.
           <BitLength>4</BitLength>
           <BitOffset>48</BitOffset>
           <BitStart>0</BitStart>
-          <Units>0=Another device controlling windlass</Units>
                  <Type>Bitfield</Type>
           <Signed>false</Signed>
+          <EnumBitValues>
+            <EnumPair Bit='0' Name='Another device controlling windlass' />
+          </EnumBitValues>
         </Field>
         <Field>
           <Order>14</Order>
@@ -13546,9 +13869,15 @@ limitations under the License.
           <BitLength>6</BitLength>
           <BitOffset>58</BitOffset>
           <BitStart>2</BitStart>
-          <Units>0=System error,1=Sensor error,2=No windlass motion detected,3=Retrieval docking distance reached,4=End or rode reached</Units>
                  <Type>Bitfield</Type>
           <Signed>false</Signed>
+          <EnumBitValues>
+            <EnumPair Bit='0' Name='System error' />
+            <EnumPair Bit='1' Name='Sensor error' />
+            <EnumPair Bit='2' Name='No windlass motion detected' />
+            <EnumPair Bit='3' Name='Retrieval docking distance reached' />
+            <EnumPair Bit='4' Name='End or rode reached' />
+          </EnumBitValues>
         </Field>
       </Fields>
     </PGNInfo>
@@ -13586,9 +13915,14 @@ limitations under the License.
           <BitLength>8</BitLength>
           <BitOffset>16</BitOffset>
           <BitStart>0</BitStart>
-          <Units>0=Controller under voltage cut-out,1=Controller over current cut-out,2=Controller over temperature cut-out,3=Manufacturer defined</Units>
                  <Type>Bitfield</Type>
           <Signed>false</Signed>
+          <EnumBitValues>
+            <EnumPair Bit='0' Name='Controller under voltage cut-out' />
+            <EnumPair Bit='1' Name='Controller over current cut-out' />
+            <EnumPair Bit='2' Name='Controller over temperature cut-out' />
+            <EnumPair Bit='3' Name='Manufacturer defined' />
+          </EnumBitValues>
         </Field>
         <Field>
           <Order>4</Order>
@@ -13861,9 +14195,9 @@ limitations under the License.
         </Field>
         <Field>
           <Order>6</Order>
-          <Id>courseOverGround</Id>
-          <Name>Course Over Ground</Name>
-          <BitLength>32</BitLength>
+          <Id>cog</Id>
+          <Name>COG</Name>
+          <BitLength>16</BitLength>
           <BitOffset>32</BitOffset>
           <BitStart>0</BitStart>
           <Units>rad</Units>
@@ -13875,7 +14209,7 @@ limitations under the License.
           <Id>altitudeDelta</Id>
           <Name>Altitude Delta</Name>
           <BitLength>16</BitLength>
-          <BitOffset>64</BitOffset>
+          <BitOffset>48</BitOffset>
           <BitStart>0</BitStart>
           <Signed>true</Signed>
         </Field>
@@ -13887,7 +14221,7 @@ limitations under the License.
       <Description>GNSS Position Data</Description>
       <Type>Fast</Type>
       <Complete>true</Complete>
-      <Length>51</Length>
+      <Length>43</Length>
       <RepeatingFields>3</RepeatingFields>
       <Fields>
         <Field>
@@ -14054,7 +14388,7 @@ limitations under the License.
           <Order>13</Order>
           <Id>pdop</Id>
           <Name>PDOP</Name>
-          <Description>Probable dilution of precision</Description>
+          <Description>Positional dilution of precision</Description>
           <BitLength>16</BitLength>
           <BitOffset>288</BitOffset>
           <BitStart>0</BitStart>
@@ -14379,7 +14713,7 @@ limitations under the License.
             <EnumPair Value='0' Name='Under way using engine' />
             <EnumPair Value='1' Name='At anchor' />
             <EnumPair Value='2' Name='Not under command' />
-            <EnumPair Value='3' Name='Restricted manoeuverability' />
+            <EnumPair Value='3' Name='Restricted maneuverability' />
             <EnumPair Value='4' Name='Constrained by her draught' />
             <EnumPair Value='5' Name='Moored' />
             <EnumPair Value='6' Name='Aground' />
@@ -14403,7 +14737,7 @@ limitations under the License.
             <EnumPair Value='0' Name='Not available' />
             <EnumPair Value='1' Name='Not engaged in special maneuver' />
             <EnumPair Value='2' Name='Engaged in special maneuver' />
-            <EnumPair Value='3' Name='Reserverd' />
+            <EnumPair Value='3' Name='Reserved' />
           </EnumValues>
         </Field>
         <Field>
@@ -14674,8 +15008,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -14690,8 +15022,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -14721,8 +15051,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -15299,7 +15627,7 @@ limitations under the License.
           <Signed>false</Signed>
           <EnumValues>
             <EnumPair Value='0' Name='Default: Type of AtoN not specified' />
-            <EnumPair Value='1' Name='Referece point' />
+            <EnumPair Value='1' Name='Reference point' />
             <EnumPair Value='2' Name='RACON' />
             <EnumPair Value='3' Name='Fixed structure off-shore' />
             <EnumPair Value='4' Name='Reserved for future use' />
@@ -15344,8 +15672,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -15360,8 +15686,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -15477,7 +15801,7 @@ limitations under the License.
       <Description>Datum</Description>
       <Type>Fast</Type>
       <Complete>true</Complete>
-      <Length>24</Length>
+      <Length>20</Length>
       <RepeatingFields>0</RepeatingFields>
       <Fields>
         <Field>
@@ -15723,8 +16047,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -15808,8 +16130,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -15824,8 +16144,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -16726,7 +17044,7 @@ limitations under the License.
         <MissingAttribute>FieldLengths</MissingAttribute>
         <MissingAttribute>Precision</MissingAttribute>
       </Missing>
-      <Length>8</Length>
+      <Length>26</Length>
       <RepeatingFields>0</RepeatingFields>
       <Fields>
         <Field>
@@ -16736,15 +17054,19 @@ limitations under the License.
           <BitLength>8</BitLength>
           <BitOffset>0</BitOffset>
           <BitStart>0</BitStart>
+                 <Type>Integer</Type>
+                 <Resolution>1</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
           <Order>2</Order>
           <Id>gpsWeekNumber</Id>
           <Name>GPS Week number</Name>
-          <BitLength>8</BitLength>
+          <BitLength>16</BitLength>
           <BitOffset>8</BitOffset>
           <BitStart>0</BitStart>
+                 <Type>Integer</Type>
+                 <Resolution>1</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
@@ -16752,17 +17074,20 @@ limitations under the License.
           <Id>svHealthBits</Id>
           <Name>SV Health Bits</Name>
           <BitLength>8</BitLength>
-          <BitOffset>16</BitOffset>
+          <BitOffset>24</BitOffset>
           <BitStart>0</BitStart>
+                 <Type>Binary data</Type>
           <Signed>false</Signed>
         </Field>
         <Field>
           <Order>4</Order>
           <Id>eccentricity</Id>
           <Name>Eccentricity</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>24</BitOffset>
+          <BitLength>16</BitLength>
+          <BitOffset>32</BitOffset>
           <BitStart>0</BitStart>
+          <Units>m/m</Units>
+          <Resolution>1e-21</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
@@ -16770,80 +17095,109 @@ limitations under the License.
           <Id>almanacReferenceTime</Id>
           <Name>Almanac Reference Time</Name>
           <BitLength>8</BitLength>
-          <BitOffset>32</BitOffset>
+          <BitOffset>48</BitOffset>
           <BitStart>0</BitStart>
+          <Units>s</Units>
+          <Resolution>1e+12</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
           <Order>6</Order>
           <Id>inclinationAngle</Id>
           <Name>Inclination Angle</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>40</BitOffset>
+          <BitLength>16</BitLength>
+          <BitOffset>56</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>semi-circle</Units>
+          <Resolution>1e-19</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>7</Order>
-          <Id>rightOfRightAscension</Id>
-          <Name>Right of Right Ascension</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>48</BitOffset>
+          <Id>rateOfRightAscension</Id>
+          <Name>Rate of Right Ascension</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>72</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>semi-circle/s</Units>
+          <Resolution>1e-38</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>8</Order>
           <Id>rootOfSemiMajorAxis</Id>
           <Name>Root of Semi-major Axis</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>56</BitOffset>
+          <BitLength>24</BitLength>
+          <BitOffset>88</BitOffset>
           <BitStart>0</BitStart>
+          <Units>sqrt(m)</Units>
+          <Resolution>1e-11</Resolution>
           <Signed>false</Signed>
         </Field>
         <Field>
           <Order>9</Order>
           <Id>argumentOfPerigee</Id>
           <Name>Argument of Perigee</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>64</BitOffset>
+          <BitLength>24</BitLength>
+          <BitOffset>112</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>semi-circle</Units>
+          <Resolution>1e-23</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>10</Order>
           <Id>longitudeOfAscensionNode</Id>
           <Name>Longitude of Ascension Node</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>72</BitOffset>
+          <BitLength>24</BitLength>
+          <BitOffset>136</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>semi-circle</Units>
+          <Resolution>1e-23</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>11</Order>
           <Id>meanAnomaly</Id>
           <Name>Mean Anomaly</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>80</BitOffset>
+          <BitLength>24</BitLength>
+          <BitOffset>160</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>semi-circle</Units>
+          <Resolution>1e-23</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>12</Order>
           <Id>clockParameter1</Id>
           <Name>Clock Parameter 1</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>88</BitOffset>
+          <BitLength>11</BitLength>
+          <BitOffset>184</BitOffset>
           <BitStart>0</BitStart>
-          <Signed>false</Signed>
+          <Units>s</Units>
+          <Resolution>1e-20</Resolution>
+          <Signed>true</Signed>
         </Field>
         <Field>
           <Order>13</Order>
           <Id>clockParameter2</Id>
           <Name>Clock Parameter 2</Name>
-          <BitLength>8</BitLength>
-          <BitOffset>96</BitOffset>
-          <BitStart>0</BitStart>
+          <BitLength>11</BitLength>
+          <BitOffset>195</BitOffset>
+          <BitStart>3</BitStart>
+          <Units>s/s</Units>
+          <Resolution>1e-38</Resolution>
+          <Signed>true</Signed>
+        </Field>
+        <Field>
+          <Order>14</Order>
+          <Id>reserved</Id>
+          <Name>Reserved</Name>
+          <Description>Reserved</Description>
+          <BitLength>2</BitLength>
+          <BitOffset>206</BitOffset>
+          <BitStart>6</BitStart>
+                 <Type>Binary data</Type>
           <Signed>false</Signed>
         </Field>
       </Fields>
@@ -20419,8 +20773,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -20720,8 +21072,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -22415,7 +22765,7 @@ limitations under the License.
             <EnumPair Value='4' Name='Main Cabin Temperature' />
             <EnumPair Value='5' Name='Live Well Temperature' />
             <EnumPair Value='6' Name='Bait Well Temperature' />
-            <EnumPair Value='7' Name='Refridgeration Temperature' />
+            <EnumPair Value='7' Name='Refrigeration Temperature' />
             <EnumPair Value='8' Name='Heating System Temperature' />
             <EnumPair Value='9' Name='Dew Point Temperature' />
             <EnumPair Value='10' Name='Apparent Wind Chill Temperature' />
@@ -22519,7 +22869,7 @@ limitations under the License.
             <EnumPair Value='4' Name='Main Cabin Temperature' />
             <EnumPair Value='5' Name='Live Well Temperature' />
             <EnumPair Value='6' Name='Bait Well Temperature' />
-            <EnumPair Value='7' Name='Refridgeration Temperature' />
+            <EnumPair Value='7' Name='Refrigeration Temperature' />
             <EnumPair Value='8' Name='Heating System Temperature' />
             <EnumPair Value='9' Name='Dew Point Temperature' />
             <EnumPair Value='10' Name='Apparent Wind Chill Temperature' />
@@ -22662,6 +23012,10 @@ limitations under the License.
             <EnumPair Value='2' Name='Steam' />
             <EnumPair Value='3' Name='Compressed Air' />
             <EnumPair Value='4' Name='Hydraulic' />
+            <EnumPair Value='5' Name='Filter' />
+            <EnumPair Value='6' Name='AltimeterSetting' />
+            <EnumPair Value='7' Name='Oil' />
+            <EnumPair Value='8' Name='Fuel' />
           </EnumValues>
         </Field>
         <Field>
@@ -22720,6 +23074,10 @@ limitations under the License.
             <EnumPair Value='2' Name='Steam' />
             <EnumPair Value='3' Name='Compressed Air' />
             <EnumPair Value='4' Name='Hydraulic' />
+            <EnumPair Value='5' Name='Filter' />
+            <EnumPair Value='6' Name='AltimeterSetting' />
+            <EnumPair Value='7' Name='Oil' />
+            <EnumPair Value='8' Name='Fuel' />
           </EnumValues>
         </Field>
         <Field>
@@ -22780,7 +23138,7 @@ limitations under the License.
             <EnumPair Value='4' Name='Main Cabin Temperature' />
             <EnumPair Value='5' Name='Live Well Temperature' />
             <EnumPair Value='6' Name='Bait Well Temperature' />
-            <EnumPair Value='7' Name='Refridgeration Temperature' />
+            <EnumPair Value='7' Name='Refrigeration Temperature' />
             <EnumPair Value='8' Name='Heating System Temperature' />
             <EnumPair Value='9' Name='Dew Point Temperature' />
             <EnumPair Value='10' Name='Apparent Wind Chill Temperature' />
@@ -23718,8 +24076,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -23734,8 +24090,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -23750,8 +24104,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -23766,8 +24118,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -23782,8 +24132,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -23812,8 +24160,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -24467,8 +24813,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -25057,8 +25401,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -25072,8 +25414,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -25457,8 +25797,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -25559,8 +25897,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -25758,8 +26094,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -26030,8 +26364,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -26046,8 +26378,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='No' />
             <EnumPair Value='1' Name='Yes' />
-            <EnumPair Value='10' Name='Error' />
-            <EnumPair Value='11' Name='Unavailable' />
           </EnumValues>
         </Field>
         <Field>
@@ -31521,6 +31851,120 @@ limitations under the License.
       </Fields>
     </PGNInfo>
     <PGNInfo>
+      <PGN>130823</PGN>
+      <Id>maretronProprietaryTemperatureHighRange</Id>
+      <Description>Maretron: Proprietary Temperature High Range</Description>
+      <Type>Fast</Type>
+      <Complete>true</Complete>
+      <Length>9</Length>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>manufacturerCode</Id>
+          <Name>Manufacturer Code</Name>
+          <Description>Maretron</Description>
+          <BitLength>11</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Match>137</Match>
+                 <Type>Manufacturer code</Type>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>2</Order>
+          <Id>reserved</Id>
+          <Name>Reserved</Name>
+          <BitLength>2</BitLength>
+          <BitOffset>11</BitOffset>
+          <BitStart>3</BitStart>
+          <Resolution>0</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>3</Order>
+          <Id>industryCode</Id>
+          <Name>Industry Code</Name>
+          <Description>Marine Industry</Description>
+          <BitLength>3</BitLength>
+          <BitOffset>13</BitOffset>
+          <BitStart>5</BitStart>
+          <Match>4</Match>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>4</Order>
+          <Id>sid</Id>
+          <Name>SID</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>16</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>5</Order>
+          <Id>instance</Id>
+          <Name>Instance</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>24</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>6</Order>
+          <Id>source</Id>
+          <Name>Source</Name>
+          <BitLength>8</BitLength>
+          <BitOffset>32</BitOffset>
+          <BitStart>0</BitStart>
+                 <Type>Lookup table</Type>
+          <Signed>false</Signed>
+          <EnumValues>
+            <EnumPair Value='0' Name='Sea Temperature' />
+            <EnumPair Value='1' Name='Outside Temperature' />
+            <EnumPair Value='2' Name='Inside Temperature' />
+            <EnumPair Value='3' Name='Engine Room Temperature' />
+            <EnumPair Value='4' Name='Main Cabin Temperature' />
+            <EnumPair Value='5' Name='Live Well Temperature' />
+            <EnumPair Value='6' Name='Bait Well Temperature' />
+            <EnumPair Value='7' Name='Refrigeration Temperature' />
+            <EnumPair Value='8' Name='Heating System Temperature' />
+            <EnumPair Value='9' Name='Dew Point Temperature' />
+            <EnumPair Value='10' Name='Apparent Wind Chill Temperature' />
+            <EnumPair Value='11' Name='Theoretical Wind Chill Temperature' />
+            <EnumPair Value='12' Name='Heat Index Temperature' />
+            <EnumPair Value='13' Name='Freezer Temperature' />
+            <EnumPair Value='14' Name='Exhaust Gas Temperature' />
+          </EnumValues>
+        </Field>
+        <Field>
+          <Order>7</Order>
+          <Id>actualTemperature</Id>
+          <Name>Actual Temperature</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>40</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>K</Units>
+                 <Type>Temperature</Type>
+                 <Resolution>0.1</Resolution>
+          <Signed>false</Signed>
+        </Field>
+        <Field>
+          <Order>8</Order>
+          <Id>setTemperature</Id>
+          <Name>Set Temperature</Name>
+          <BitLength>16</BitLength>
+          <BitOffset>56</BitOffset>
+          <BitStart>0</BitStart>
+          <Units>K</Units>
+                 <Type>Temperature</Type>
+                 <Resolution>0.1</Resolution>
+          <Signed>false</Signed>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
       <PGN>130824</PGN>
       <Id>bGWindData</Id>
       <Description>B&amp;G: Wind data</Description>
@@ -32238,8 +32682,8 @@ limitations under the License.
         </Field>
         <Field>
           <Order>4</Order>
-          <Id>bankInstance</Id>
-          <Name>Bank Instance</Name>
+          <Id>instance</Id>
+          <Name>Instance</Name>
           <BitLength>8</BitLength>
           <BitOffset>16</BitOffset>
           <BitStart>0</BitStart>
@@ -32325,7 +32769,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -32435,8 +32878,8 @@ limitations under the License.
         </Field>
         <Field>
           <Order>4</Order>
-          <Id>bankInstance</Id>
-          <Name>Bank Instance</Name>
+          <Id>instance</Id>
+          <Name>Instance</Name>
           <BitLength>8</BitLength>
           <BitOffset>16</BitOffset>
           <BitStart>0</BitStart>
@@ -32522,7 +32965,6 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Off' />
             <EnumPair Value='1' Name='On' />
-            <EnumPair Value='2' Name='Failed' />
           </EnumValues>
         </Field>
         <Field>
@@ -35012,6 +35454,48 @@ limitations under the License.
           <EnumValues>
             <EnumPair Value='0' Name='Pass' />
           </EnumValues>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
+      <PGN>065299</PGN>
+      <Id>FirstDisplayError</Id>
+      <Description>Error: 2</Description>
+      <Complete>true</Complete>
+      <Length>8</Length>
+      <Type>Binary data</Type>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>data</Id>
+          <Name>Data</Name>
+          <BitLength>56</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+          <Type>Binary data</Type>
+        </Field>
+      </Fields>
+    </PGNInfo>
+    <PGNInfo>
+      <PGN>065300</PGN>
+      <Id>SecondDisplayError</Id>
+      <Description>Error: 2</Description>
+      <Complete>true</Complete>
+      <Length>7</Length>
+      <Type>Binary data</Type>
+      <RepeatingFields>0</RepeatingFields>
+      <Fields>
+        <Field>
+          <Order>1</Order>
+          <Id>data</Id>
+          <Name>Data</Name>
+          <BitLength>56</BitLength>
+          <BitOffset>0</BitOffset>
+          <BitStart>0</BitStart>
+          <Signed>false</Signed>
+          <Type>Binary data</Type>
         </Field>
       </Fields>
     </PGNInfo>

--- a/n2k-codegen/src/lib.rs
+++ b/n2k-codegen/src/lib.rs
@@ -553,7 +553,12 @@ fn codegen_get_impl(
             }
         }
     } else if field.is_float() {
-        let resolution = TokenStream::from_str(&field.resolution.to_string()).unwrap();
+        let resolution = if let Some(t) = rust_type.clone() {
+            format!("{}_{}", field.resolution, t)
+        } else {
+            field.resolution.to_string()
+        };
+        let resolution = TokenStream::from_str(&resolution).unwrap();
         let raw_type = field.rust_raw_type();
         // float
         quote! {
@@ -563,7 +568,7 @@ fn codegen_get_impl(
                 if raw_value == #raw_type::MAX {
                     None
                 } else {
-                    Some((raw_value as #rust_type) * (#resolution as #rust_type))
+                    Some((raw_value as #rust_type) * #resolution)
                 }
             }
         }

--- a/n2k-codegen/src/lib.rs
+++ b/n2k-codegen/src/lib.rs
@@ -6,7 +6,7 @@ use log::*;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     path::Path,
 };
 use std::{fs::File, str::FromStr};
@@ -19,7 +19,7 @@ use canboatxml::*;
 
 pub struct N2kCodeGenOpts {
     pub pgns_xml: String,
-    pub pgns: HashSet<u32>,
+    pub pgns: BTreeSet<u32>,
     pub output: PathBuf,
     /// Whether to generate a crate, and its name. Generates a module otherwise
     pub generate_crate: Option<String>,
@@ -28,7 +28,7 @@ pub struct N2kCodeGenOpts {
 pub fn codegen(opts: N2kCodeGenOpts) {
     // Preserve a consistent order when generating code
     let mut pgns_to_generate: Vec<_> = opts.pgns.iter().cloned().collect();
-    pgns_to_generate.sort_unstable();
+    pgns_to_generate.sort();
 
     let dest_path = if opts.generate_crate.is_some() {
         opts.output.join("src")
@@ -237,8 +237,8 @@ fn codegen_pgns_variant_enum(pgns_file: &PgnsFile, pgns: &Vec<u32>) -> TokenStre
 fn codegen_pgns_enum(pgns: &PgnsFile) -> TokenStream {
     let mut enum_fields = vec![];
     let mut enum_match_arms = vec![];
-    let mut names_seen = HashSet::new();
-    let pgn_ids: HashSet<_> = pgns.pgns.pgn_infos.iter().map(|v| v.pgn).collect();
+    let mut names_seen = BTreeSet::new();
+    let pgn_ids: BTreeSet<_> = pgns.pgns.pgn_infos.iter().map(|v| v.pgn).collect();
 
     for pgn_id in &pgn_ids {
         let names: Vec<_> = pgns
@@ -444,7 +444,7 @@ fn codegen_getters(pgninfo: &PgnInfo) -> (TokenStream, Vec<String>) {
     let mut getters = vec![];
     let mut generated_fields = vec![];
 
-    let mut seen_fields: HashMap<String, u32> = HashMap::new();
+    let mut seen_fields: BTreeMap<String, u32> = BTreeMap::new();
     for field in &pgninfo.fields.fields {
         if field.id == "reserved" {
             continue;


### PR DESCRIPTION
Turns out that Jacob wasn't able to push changes he made to `pgns.xml` in July due to missing permissions.

These changes make the generator's output consistent with the code that we're actually using. They also make the generator deterministic, so that diffs are minimized.